### PR TITLE
Ensure assignment statements read all variables before writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Because TLC is designed to fit in a single file and be easily understood, we dec
 
 - **Debug Symbols:** We don't strip line numbers or debug info, we never generate them! This drastically simplifies the Tokenizer and Parser.
 - **[Constant Folding](https://en.wikipedia.org/wiki/Constant_folding):** Standard Lua converts `local x = 2 + 3` into `local x = 5` at compile time. TLC calculates this at runtime.
-- **Edge-Case Assignments:** Simultaneous assignments where the Left-Hand Side depends on a variable changing in the same statement (e.g., [`i, a[i] = i+1, 20`](https://www.lua.org/manual/5.1/manual.html#2.4.3)) are rare, but TLC may evaluate them differently than the standard C implementation.
 - **Unused Opcodes:** We skip `CLOSE` (which may break some code relying on it), `TESTSET` (it's just an optimization), and massive table constructors (over ~25k items).
 
 Everything else should work just like standard Lua 5.1!


### PR DESCRIPTION
In case the same variable is assigned and used as a base or index in the left-hand side of an assignment statement, the order sometimes allowed for the assignment to happen before the read. This PR should fix this issue and ensures that all read happen before writes in assignment expressions.

This is done by changing the functionality of the `setRegisterValue` function to handle the full list of assignments.
It now first does all the reads in case it handles and index assignment and then calls itself recursively to do the other assignments. After the recursive call returns the assignment is actually performed. This order ensures all reads are performed before the writes.

Since the functionality of the `setRegisterValue` changed I renamed it. Since I don't know how API stable this project is I added the now unused `setRegisterValue` back in case code outside of this codebase uses it.