### PR TITLE
Bad handling of false

### DIFF
--- a/the-tiny-lua-compiler.lua
+++ b/the-tiny-lua-compiler.lua
@@ -3774,7 +3774,8 @@ function VirtualMachine:executeClosure(...)
   -- in our implementation, so in order to get the correct constant,
   -- we negate the index when accessing the constants table.
   local function rk(index)
-    return stack[index] or constants[-index]
+    if index < 0 then return constants[-index] end
+    return stack[index]
   end
 
   -- Initialize parameters.


### PR DESCRIPTION
The `rk` function of the VM was converting `false` into `nil` values due to the `or` operator. This caused scripts like `print(false==nil)` to output `true`.

Fix this by using an if statement instead.