### PR TITLE
For loop might remove local variable

### DIFF
--- a/the-tiny-lua-compiler.lua
+++ b/the-tiny-lua-compiler.lua
@@ -2882,6 +2882,7 @@ function CodeGenerator:processForGenericStatement(node)
   local expressions = node.expressions
   local body        = node.body
 
+  self:enterScope()
   local baseRegister = self.stackSize
   local expressionRegisters = self:processExpressionList(expressions, 3)
   self:declareLocalVariables(iterators)
@@ -2900,8 +2901,7 @@ function CodeGenerator:processForGenericStatement(node)
     -- Emit jump back to the start of the loop if there are more values.
     self:emitJumpBack(loopStartPC)
   end)
-  self:undeclareVariables(iterators)
-  self:freeRegisters(#iterators + expressionRegisters)
+  self:leaveScope()
 end
 
 function CodeGenerator:processForNumericStatement(node)
@@ -2911,6 +2911,7 @@ function CodeGenerator:processForNumericStatement(node)
   local stepExpr  = node.step
   local body      = node.body
 
+  self:enterScope()
   local startRegister = self:processExpressionNode(startExpr)
   self:processExpressionNode(limitExpr)
   local stepRegister = self:allocateRegisters(1)
@@ -2938,8 +2939,7 @@ function CodeGenerator:processForNumericStatement(node)
     --                       if R(A) <?= R(A+1) then { pc+=sBx R(A+3)=R(A) }
     self:emitInstruction("FORLOOP", startRegister, loopStartPC - loopEndPC - 1)
   end)
-  self:freeRegisters(3) -- Free startRegister, endRegister, stepRegister
-  self:undeclareVariable(varName)
+  self:leaveScope()
 end
 
 function CodeGenerator:processWhileStatement(node)


### PR DESCRIPTION
In case the iteration variable of a loop shadows a variable in the outer scope it will be removed due to the use of `undeclareVariable` as seen in
```lua
local i=3
for i=1,1 do
end
print(i)
```
Instead add a new scope for the iteration variables preventing shadowed variables from being removed.

The `undeclareVariable` and `undeclareVariables` methods are now unused and could be removed.