### PR TITLE
Implement support for CLOSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Because TLC is designed to fit in a single file and be easily understood, we dec
 - **Debug Symbols:** We don't strip line numbers or debug info, we never generate them! This drastically simplifies the Tokenizer and Parser.
 - **[Constant Folding](https://en.wikipedia.org/wiki/Constant_folding):** Standard Lua converts `local x = 2 + 3` into `local x = 5` at compile time. TLC calculates this at runtime.
 - **Edge-Case Assignments:** Simultaneous assignments where the Left-Hand Side depends on a variable changing in the same statement (e.g., [`i, a[i] = i+1, 20`](https://www.lua.org/manual/5.1/manual.html#2.4.3)) are rare, but TLC may evaluate them differently than the standard C implementation.
-- **Unused Opcodes:** We skip `CLOSE` (which may break some code relying on it), `TESTSET` (it's just an optimization), and massive table constructors (over ~25k items).
+- **Unused Opcodes:** We skip `TESTSET` (it's just an optimization), and massive table constructors (over ~25k items).
 
 Everything else should work just like standard Lua 5.1!
 

--- a/the-tiny-lua-compiler.lua
+++ b/the-tiny-lua-compiler.lua
@@ -2980,6 +2980,11 @@ function CodeGenerator:processRepeatStatement(node)
     self:processStatementList(body.statements)
     local conditionRegister = self:processExpressionNode(condition)
 
+    if self.currentScope.needClose then
+      self:emitInstruction("CLOSE", self.currentScope.parentScope.stackSize, 0, 0)
+      self.currentScope.needClose = false
+    end
+
     -- OP_TEST [A, C]    if not (R(A) <=> C) then pc++
     self:emitInstruction("TEST", conditionRegister, 0, 0)
     self:emitJumpBack(loopStartPC)


### PR DESCRIPTION
TTLC is not fully self-hosting as the VM relies on correct upvalue close behavior for the closure implementation in
https://github.com/bytexenon/The-Tiny-Lua-Compiler/blob/ca95cdbd2e906e78121322ab1fc945554a529fd2/the-tiny-lua-compiler.lua#L4251-L4257

This also fixes `break` being allowed outside of loops.